### PR TITLE
Fixed missing header in income csv

### DIFF
--- a/cleaned_data/median-income-data.csv
+++ b/cleaned_data/median-income-data.csv
@@ -1,3 +1,4 @@
+County,Income
 Anderson,"$48,461"
 Andrews,"$74,918"
 Angelina,"$51,750"

--- a/data_cleaning/compile_income.py
+++ b/data_cleaning/compile_income.py
@@ -6,6 +6,6 @@ from unicodedata import normalize
 table = pd.read_html('https://txcip.org/tac/census/morecountyinfo.php?MORE=1013', skiprows=1, header=None)
 
 uRate = table[0]
-
-uRate.to_csv('../cleaned_data/median-income-data.csv', index=False, header=False)
+strList = ['County', 'Income']
+uRate.to_csv('../cleaned_data/median-income-data.csv', index=False, header=strList)
 print(uRate)


### PR DESCRIPTION
add list of strings to be header for County and Income columns.